### PR TITLE
Fix out-of-bounds read for an empty input file

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -426,21 +426,22 @@ int main(int argc, char **argv)
 
   /* Pre-sort roots */
   i = 0;
-  while(i < roots_len -1)
-    {
-      j = i+1;
-      max = i;
-      while(j < roots_len)
-        {
-          if(tree[roots[j]].w > tree[roots[max]].w) max = j;
-          j++;
-        }
-      aux = roots[i];
-      roots[i] = roots[max];
-      roots[max] = aux;
-      i++;
-    }
-
+  if (roots_len != 0) {
+    while(i < roots_len -1)
+      {
+        j = i+1;
+        max = i;
+        while(j < roots_len)
+          {
+            if(tree[roots[j]].w > tree[roots[max]].w) max = j;
+            j++;
+          }
+        aux = roots[i];
+        roots[i] = roots[max];
+        roots[max] = aux;
+        i++;
+      }
+  }
 
   while(roots_len > 1)
     {


### PR DESCRIPTION
The loop condition for pre-sorting the roots is `i < roots_len -1`.
When the input file is empty, `roots_len` is `0`. Since `i` is an
unsigned long, the right side of the expression yields `ULONG_MAX`
instead of a negative number or zero, which consequently results
in an out-of-bounds read.

This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).